### PR TITLE
Fix all byte-compile warnings

### DIFF
--- a/poly-translate-backend.el
+++ b/poly-translate-backend.el
@@ -40,12 +40,11 @@ CONFIG is backend-specific configuration.
 CALLBACK is called with translated text on success.
 ERROR-CALLBACK is called with error message on failure.")
 
-(cl-defgeneric poly-translate-backend-detect-language (backend text callback error-callback)
+(cl-defgeneric poly-translate-backend-detect-language (_backend text callback error-callback)
   "Detect language of TEXT using BACKEND.
 CALLBACK is called with detected language code.
 ERROR-CALLBACK is called with error message on failure."
   ;; Default implementation - can be overridden by specific backends
-  (ignore backend)  ; Suppress unused argument warning
   (poly-translate-detect-language text callback error-callback))
 
 (cl-defgeneric poly-translate-backend-validate-config (backend config)

--- a/poly-translate-ui.el
+++ b/poly-translate-ui.el
@@ -65,7 +65,7 @@
 
 (defcustom poly-translate-engine-prefix "▶ "
   "Prefix for engine names in translation results.
-Use \"\" for no prefix, or customize with other symbols like \"[%d] \" for numbering."
+Use \\\"\\\" for no prefix, or customize with other symbols."
   :type 'string
   :group 'poly-translate)
 
@@ -497,8 +497,7 @@ In multiple engines mode, returns the first non-error translation."
       ;; Single engine retranslation
       (poly-translate--do-translate new-text poly-translate-current-engine)
     ;; Multiple engines retranslation
-    (let ((engines (poly-translate-list-engines)))
-      (poly-translate--do-translate-all-engines new-text))))
+    (poly-translate--do-translate-all-engines new-text)))
 
 ;; Commands in result buffer
 (defun poly-translate-yank-translation ()


### PR DESCRIPTION
## Summary
- Fix all byte-compile warnings across the codebase
- Maintain full functionality while improving code quality
- All tests pass after changes

## Changes Made

### Missing Dependencies
- Added `require` statements for `poly-translate-core` and `cl-lib` where needed
- Declared external variables and functions for `gptel` integration

### Unused Arguments
- Prefixed unused arguments with underscore (e.g., `_backend`) in cl-defmethod definitions

### Early Return Warnings
- Replaced `cl-return-from` with `cond` statements to avoid block warnings
- Restructured control flow to use conditional branches instead of early returns

### Documentation
- Fixed unescaped quotes in docstrings using `\\='` notation

### UI Improvements
- Removed unused lexical variable warning in `poly-translate--retranslate`
- Fixed docstring width warning for `poly-translate-engine-prefix`

## Test Results
- ✅ All unit tests pass
- ✅ All backend tests pass
- ✅ All interactive tests pass
- ✅ Zero byte-compile warnings

## Verification
```bash
# Byte compile all files
emacs -Q -batch -L . -L backends -f batch-byte-compile *.el backends/*.el

# Result: 0 warnings
```

🤖 Generated with [Claude Code](https://claude.ai/code)