### PR TITLE
Add language pair switching functionality

### DIFF
--- a/poly-translate-core.el
+++ b/poly-translate-core.el
@@ -177,6 +177,39 @@ ERROR-CALLBACK is called with error message on failure."
                (t "en"))))
     (funcall callback lang)))
 
+;; Language pair management functions
+(defun poly-translate-list-language-pairs-for-backend (backend)
+  "Return a list of language pairs for BACKEND.
+Each element is a cons cell (INPUT-LANG . OUTPUT-LANG)."
+  (let ((pairs nil))
+    (maphash (lambda (_name engine)
+               (when (eq (poly-translate-engine-backend engine) backend)
+                 (let ((input-lang (poly-translate-engine-input-lang engine))
+                       (output-lang (poly-translate-engine-output-lang engine)))
+                   (cl-pushnew (cons input-lang output-lang) pairs :test #'equal))))
+             poly-translate-engines)
+    (sort pairs (lambda (a b)
+                  (string< (format "%s-%s" (car a) (cdr a))
+                           (format "%s-%s" (car b) (cdr b)))))))
+
+(defun poly-translate-find-engine-for-language-pair (backend input-lang output-lang)
+  "Find an engine using BACKEND with INPUT-LANG to OUTPUT-LANG.
+Returns the engine name if found, nil otherwise."
+  (catch 'found
+    (maphash (lambda (name engine)
+               (when (and (eq (poly-translate-engine-backend engine) backend)
+                          (string= (poly-translate-engine-input-lang engine) input-lang)
+                          (string= (poly-translate-engine-output-lang engine) output-lang))
+                 (throw 'found name)))
+             poly-translate-engines)
+    nil))
+
+(defun poly-translate-format-language-pair (input-lang output-lang)
+  "Format language pair for display."
+  (format "%s → %s"
+          (poly-translate-language-name input-lang)
+          (poly-translate-language-name output-lang)))
+
 ;; Utility functions
 (defun poly-translate-language-name (code)
   "Get the display name for language CODE."

--- a/poly-translate-ui.el
+++ b/poly-translate-ui.el
@@ -100,6 +100,8 @@ Use \\\"\\\" for no prefix, or customize with other symbols."
     (define-key map "y" #'poly-translate-yank-translation)
     (define-key map "e" #'poly-translate-toggle-edit-original)
     (define-key map "c" #'poly-translate-change-engine)
+    (define-key map "l" #'poly-translate-switch-language-pair)
+
     (define-key map "s" #'poly-translate-save-translation)
     (define-key map (kbd "C-c C-c") #'poly-translate--finish-edit-original)
     (define-key map (kbd "C-c C-k") #'poly-translate--cancel-edit-original)
@@ -141,6 +143,56 @@ If TO-KILL-RING is non-nil, add result to kill ring instead of showing buffer."
              (member poly-translate-default-engine engines))
         poly-translate-default-engine
       (completing-read "Translation engine: " engines nil t))))
+
+(defun poly-translate--switch-to-language-pair (backend)
+  "Switch to a different language pair for BACKEND."
+  (let* ((language-pairs (poly-translate-list-language-pairs-for-backend backend))
+         (current-engine-obj (poly-translate-get-engine poly-translate-current-engine))
+         (current-input (poly-translate-engine-input-lang current-engine-obj))
+         (current-output (poly-translate-engine-output-lang current-engine-obj))
+         (current-pair (cons current-input current-output)))
+
+    (when (null language-pairs)
+      (error "No language pairs available for backend %s" backend))
+
+    (when (= (length language-pairs) 1)
+      (error "Only one language pair available for backend %s" backend))
+
+    ;; Create choices list with formatted language pairs
+    (let* ((choices (mapcar (lambda (pair)
+                              (let ((input (car pair))
+                                    (output (cdr pair)))
+                                (cons (poly-translate-format-language-pair input output)
+                                      pair)))
+                            language-pairs))
+           ;; Filter out current language pair
+           (filtered-choices (seq-remove (lambda (choice)
+                                           (equal (cdr choice) current-pair))
+                                         choices)))
+
+      (when (null filtered-choices)
+        (error "No other language pairs available for backend %s" backend))
+
+      ;; Prompt user to select new language pair
+      (let* ((selected-display (completing-read
+                                (format "Switch language pair (current: %s): "
+                                        (poly-translate-format-language-pair current-input current-output))
+                                (mapcar #'car filtered-choices)
+                                nil t))
+             (selected-pair (cdr (assoc selected-display filtered-choices)))
+             (new-input (car selected-pair))
+             (new-output (cdr selected-pair))
+             (new-engine (poly-translate-find-engine-for-language-pair backend new-input new-output)))
+
+        (if new-engine
+            (progn
+              (setq poly-translate-current-engine new-engine)
+              (poly-translate--do-translate poly-translate-original-text new-engine)
+              (message "Switched to language pair: %s" selected-display))
+          (error "No engine found for language pair %s → %s with backend %s"
+                 (poly-translate-language-name new-input)
+                 (poly-translate-language-name new-output)
+                 backend))))))
 
 ;; Interactive commands
 ;;;###autoload
@@ -217,11 +269,11 @@ If ENGINE is not specified, use the default engine or prompt user."
         (insert text)
         (setq poly-translate--original-end (point))
         ;; Mark original text as read-only initially
-        (put-text-property poly-translate--original-start 
-                           poly-translate--original-end 
+        (put-text-property poly-translate--original-start
+                           poly-translate--original-end
                            'read-only t)
-        (put-text-property poly-translate--original-start 
-                           poly-translate--original-end 
+        (put-text-property poly-translate--original-start
+                           poly-translate--original-end
                            'poly-translate-section 'original)
         (insert "\n\n")
         (insert poly-translate-separator-main "\n\n"))
@@ -243,7 +295,7 @@ If ENGINE is not specified, use the default engine or prompt user."
                                   'engine-name engine) "\n")))))
 
       ;; Footer placeholder
-      (insert (propertize "Press 'q' to quit, 'g' to refresh, 'e' to edit original"
+      (insert (propertize "Press 'q' to quit, 'g' to refresh, 'e' to edit original, 'c' to change engine"
                           'face 'font-lock-comment-face))
 
       (goto-char (point-min))
@@ -310,11 +362,11 @@ If ENGINE is not specified, use the default engine or prompt user."
         (insert original)
         (setq poly-translate--original-end (point))
         ;; Mark original text as read-only initially
-        (put-text-property poly-translate--original-start 
-                           poly-translate--original-end 
+        (put-text-property poly-translate--original-start
+                           poly-translate--original-end
                            'read-only t)
-        (put-text-property poly-translate--original-start 
-                           poly-translate--original-end 
+        (put-text-property poly-translate--original-start
+                           poly-translate--original-end
                            'poly-translate-section 'original)
         (insert "\n\n")
         (insert poly-translate-separator-main "\n\n"))
@@ -336,7 +388,7 @@ If ENGINE is not specified, use the default engine or prompt user."
       (insert poly-translate-separator-engine "\n\n")
 
       ;; Footer
-      (insert (propertize "Press 'q' to quit, 'g' to refresh, 'y' to yank, 'e' to edit original, 'c' to change engine"
+      (insert (propertize "Press 'q' to quit, 'g' to refresh, 'y' to yank, 'e' to edit original, 'c' to change engine, 'l' to switch language pair"
                           'face 'font-lock-comment-face))
 
       (goto-char (point-min))
@@ -434,16 +486,16 @@ In multiple engines mode, returns the first non-error translation."
 
 (defun poly-translate--start-edit-original ()
   "Start editing the original text."
-  (when (and poly-translate--original-start 
+  (when (and poly-translate--original-start
              poly-translate--original-end)
     (let ((inhibit-read-only t))
       ;; Make original text editable
-      (put-text-property poly-translate--original-start 
-                         poly-translate--original-end 
+      (put-text-property poly-translate--original-start
+                         poly-translate--original-end
                          'read-only nil)
       ;; Add visual feedback
-      (put-text-property poly-translate--original-start 
-                         poly-translate--original-end 
+      (put-text-property poly-translate--original-start
+                         poly-translate--original-end
                          'face 'highlight)
       ;; Set edit mode flag
       (setq poly-translate--edit-mode t)
@@ -468,18 +520,18 @@ In multiple engines mode, returns the first non-error translation."
 (defun poly-translate--finish-edit-original ()
   "Finish editing original text and retranslate."
   (when poly-translate--edit-mode
-    (let ((new-text (buffer-substring-no-properties 
-                     poly-translate--original-start 
+    (let ((new-text (buffer-substring-no-properties
+                     poly-translate--original-start
                      poly-translate--original-end)))
       ;; Update original text variable
       (setq poly-translate-original-text new-text)
       ;; End edit mode
       (let ((inhibit-read-only t))
-        (put-text-property poly-translate--original-start 
-                           poly-translate--original-end 
+        (put-text-property poly-translate--original-start
+                           poly-translate--original-end
                            'read-only t)
-        (remove-text-properties poly-translate--original-start 
-                                poly-translate--original-end 
+        (remove-text-properties poly-translate--original-start
+                                poly-translate--original-end
                                 '(face nil)))
       (setq poly-translate--edit-mode nil)
       ;; Restore original keymap and read-only status
@@ -499,11 +551,11 @@ In multiple engines mode, returns the first non-error translation."
       (insert poly-translate-original-text)
       (setq poly-translate--original-end (point))
       ;; End edit mode
-      (put-text-property poly-translate--original-start 
-                         poly-translate--original-end 
+      (put-text-property poly-translate--original-start
+                         poly-translate--original-end
                          'read-only t)
-      (remove-text-properties poly-translate--original-start 
-                              poly-translate--original-end 
+      (remove-text-properties poly-translate--original-start
+                              poly-translate--original-end
                               '(face nil)))
     (setq poly-translate--edit-mode nil)
     ;; Restore original keymap and read-only status
@@ -536,6 +588,20 @@ In multiple engines mode, returns the first non-error translation."
   (when poly-translate-original-text
     (let ((new-engine (poly-translate--select-engine)))
       (poly-translate--do-translate poly-translate-original-text new-engine))))
+
+(defun poly-translate-switch-language-pair ()
+  "Switch to a different language pair using the same backend."
+  (interactive)
+  (unless poly-translate-original-text
+    (error "No original text to retranslate"))
+
+  (if poly-translate-current-engine
+      ;; Single engine mode
+      (let* ((current-engine-obj (poly-translate-get-engine poly-translate-current-engine))
+             (backend (poly-translate-engine-backend current-engine-obj)))
+        (poly-translate--switch-to-language-pair backend))
+    ;; Multiple engines mode - not supported for language pair switching
+    (error "Language pair switching is only available in single engine mode. Use 'c' to change engine instead.")))
 
 (defun poly-translate-refresh ()
   "Refresh the current translation."

--- a/poly-translate-ui.el
+++ b/poly-translate-ui.el
@@ -100,7 +100,7 @@ Use \\\"\\\" for no prefix, or customize with other symbols."
     (define-key map "y" #'poly-translate-yank-translation)
     (define-key map "e" #'poly-translate-toggle-edit-original)
     (define-key map "c" #'poly-translate-change-engine)
-    (define-key map "l" #'poly-translate-switch-language-pair)
+    (define-key map "l" 'poly-translate-switch-language-pair)
 
     (define-key map "s" #'poly-translate-save-translation)
     (define-key map (kbd "C-c C-c") #'poly-translate--finish-edit-original)


### PR DESCRIPTION
## Summary
- 翻訳結果画面で言語ペアの切り替え機能を追加
- `l` キーで同一バックエンド内の異なる言語ペアに切り替え可能

## 実装内容

### 新機能
- `poly-translate-switch-language-pair`: 言語ペア切り替えのメインコマンド
- キーバインド `l` を追加（Language switchingの意味）
- 単一エンジンモードでのみ利用可能

### コア機能
- `poly-translate-list-language-pairs-for-backend`: 指定バックエンドの利用可能言語ペアを取得
- `poly-translate-find-engine-for-language-pair`: 指定言語ペアのエンジンを検索
- `poly-translate-format-language-pair`: 言語ペアの表示フォーマット

### UI改善
- フッターヘルプテキストに `l` キーの説明を追加
- インタラクティブな言語ペア選択インターフェース
- 適切なエラーハンドリングとユーザーフィードバック

## 使用方法
1. 翻訳結果表示中に `l` キーを押す
2. 現在使用中のバックエンドで利用可能な言語ペアのリストが表示される
3. ユーザーが新しい言語ペアを選択
4. 同じ原文で新しい言語ペアによる翻訳が実行される

## Test plan
- [ ] 複数の言語ペアを持つバックエンドで `l` キーの動作確認
- [ ] 単一言語ペアのバックエンドでの適切なエラーメッセージ確認
- [ ] 複数エンジンモードでの制限メッセージ確認
- [ ] フッターヘルプテキストの表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)