### PR TITLE
Add tests for Emacs Lisp code

### DIFF
--- a/tests/poly-translate-interactive-test.el
+++ b/tests/poly-translate-interactive-test.el
@@ -264,5 +264,337 @@
 
   (poly-translate-test-teardown))
 
+;;; Edit Original Text Tests
+
+(ert-deftest poly-translate-test-edit-original-text ()
+  "Test editing original text and retranslating."
+  (poly-translate-test-setup)
+
+  ;; Set up mock backend and engine
+  (poly-translate-test-register-mock-backend 'mock-backend)
+  (poly-translate-test-register-mock-engine "Mock Engine" 'mock-backend "en" "ja")
+
+  (let ((buffer (get-buffer-create "*test-edit-translation*")))
+    (with-current-buffer buffer
+      (poly-translate-mode)
+      (let ((inhibit-read-only t))
+        (insert "Translation Result\n")
+        (insert "═════════════════════════════════════════════════\n\n")
+        (insert "Original:\n")
+        (setq poly-translate--original-start (point))
+        (insert "Hello world")
+        (setq poly-translate--original-end (point))
+        (put-text-property poly-translate--original-start
+                           poly-translate--original-end
+                           'read-only t)
+        (put-text-property poly-translate--original-start
+                           poly-translate--original-end
+                           'poly-translate-section 'original)
+        (insert "\n\n"))
+      (setq poly-translate-original-text "Hello world")
+      (setq poly-translate-current-engine "Mock Engine"))
+
+    ;; Test starting edit mode
+    (with-current-buffer buffer
+      (goto-char poly-translate--original-start)
+      (poly-translate--start-edit-original)
+      (should poly-translate--edit-mode)
+      (should (not (get-text-property poly-translate--original-start 'read-only))))
+
+    ;; Test canceling edit
+    (with-current-buffer buffer
+      (goto-char poly-translate--original-start)
+      (insert "Modified ")
+      (poly-translate--cancel-edit-original)
+      (should (not poly-translate--edit-mode))
+      (let ((text (buffer-substring-no-properties
+                   poly-translate--original-start
+                   poly-translate--original-end)))
+        (should (string= text "Hello world"))))
+
+    (kill-buffer buffer))
+
+  (poly-translate-test-teardown))
+
+(ert-deftest poly-translate-test-toggle-edit-original ()
+  "Test toggling edit mode."
+  (poly-translate-test-setup)
+
+  (let ((buffer (get-buffer-create "*test-toggle-edit*")))
+    (with-current-buffer buffer
+      (poly-translate-mode)
+      (let ((inhibit-read-only t))
+        (setq poly-translate--original-start (point-min))
+        (insert "Test text")
+        (setq poly-translate--original-end (point))
+        (put-text-property poly-translate--original-start
+                           poly-translate--original-end
+                           'read-only t)))
+
+    ;; Toggle on
+    (with-current-buffer buffer
+      (poly-translate-toggle-edit-original)
+      (should poly-translate--edit-mode))
+
+    ;; Toggle off (finish edit)
+    (with-current-buffer buffer
+      (setq poly-translate-current-engine "Mock Engine")
+      (setq poly-translate-original-text "Test text")
+      ;; Mock the retranslation
+      (cl-letf (((symbol-function 'poly-translate--retranslate)
+                 (lambda (text) (message "Retranslating: %s" text))))
+        (poly-translate-toggle-edit-original)
+        (should (not poly-translate--edit-mode))))
+
+    (kill-buffer buffer))
+
+  (poly-translate-test-teardown))
+
+;;; All Engines Translation Tests
+
+(ert-deftest poly-translate-test-all-engines-translation ()
+  "Test translation with all engines."
+  (poly-translate-test-setup)
+
+  ;; Register multiple mock backends and engines
+  (poly-translate-test-register-mock-backend 'backend1)
+  (poly-translate-test-register-mock-backend 'backend2)
+  (poly-translate-test-register-mock-engine "Engine 1" 'backend1 "en" "ja")
+  (poly-translate-test-register-mock-engine "Engine 2" 'backend2 "en" "ja")
+
+  ;; Test all engines translation
+  (let ((poly-translate-use-all-engines t))
+    (should
+     (condition-case nil
+         (progn
+           (poly-translate--do-translate-all-engines "Test text")
+           t)
+       (error nil))))
+
+  (poly-translate-test-teardown))
+
+(ert-deftest poly-translate-test-all-engines-with-errors ()
+  "Test all engines translation when some engines fail."
+  (poly-translate-test-setup)
+
+  ;; Register one successful and one failing backend
+  (poly-translate-test-register-mock-backend 'good-backend)
+  (poly-translate-register-backend
+   'bad-backend
+   `(:translate ,(lambda (backend text from-lang to-lang config callback error-callback)
+                   (funcall error-callback "Simulated error"))
+     :validate-config ,(lambda (backend config) t)))
+
+  (poly-translate-test-register-mock-engine "Good Engine" 'good-backend "en" "ja")
+  (poly-translate-register-engine
+   '(:name "Bad Engine"
+     :backend bad-backend
+     :input-lang "en"
+     :output-lang "ja"))
+
+  ;; Test that translation completes despite one engine failing
+  (should
+   (condition-case nil
+       (progn
+         (poly-translate--do-translate-all-engines "Test text")
+         t)
+     (error nil)))
+
+  (poly-translate-test-teardown))
+
+(ert-deftest poly-translate-test-all-engines-empty-list ()
+  "Test all engines translation with no engines registered."
+  (poly-translate-test-setup)
+
+  ;; Ensure no engines are registered
+  (clrhash poly-translate-engines)
+
+  ;; Should error when no engines available
+  (should-error
+   (poly-translate--do-translate-all-engines "Test text"))
+
+  (poly-translate-test-teardown))
+
+;;; History Management Tests
+
+(ert-deftest poly-translate-test-history-display ()
+  "Test translation history display."
+  (poly-translate-test-setup)
+
+  ;; Add some history entries
+  (setq poly-translate-history
+        (list
+         (list :engine "Engine 1"
+               :original "Hello"
+               :translation "こんにちは")
+         (list :engine "Engine 2"
+               :original "World"
+               :translation "世界")))
+
+  ;; Show history
+  (poly-translate-show-history)
+
+  (let ((history-buffer (get-buffer "*poly-translate-history*")))
+    (should (buffer-live-p history-buffer))
+    (with-current-buffer history-buffer
+      (let ((content (buffer-string)))
+        (poly-translate-test-should-contain content "Translation History")
+        (poly-translate-test-should-contain content "Engine 1")
+        (poly-translate-test-should-contain content "Hello")
+        (poly-translate-test-should-contain content "こんにちは")))
+    (kill-buffer history-buffer))
+
+  (poly-translate-test-teardown))
+
+;;; Kill Ring Tests
+
+(ert-deftest poly-translate-test-kill-ring-limit ()
+  "Test translation kill ring respects maximum size."
+  (poly-translate-test-setup)
+
+  (let ((poly-translate-kill-ring-max 3))
+    ;; Add more than max items
+    (poly-translate--add-to-kill-ring "Translation 1")
+    (poly-translate--add-to-kill-ring "Translation 2")
+    (poly-translate--add-to-kill-ring "Translation 3")
+    (poly-translate--add-to-kill-ring "Translation 4")
+    (poly-translate--add-to-kill-ring "Translation 5")
+
+    ;; Should only have 3 items
+    (should (= (length poly-translate-kill-ring) 3))
+    ;; Most recent should be first
+    (should (string= (car poly-translate-kill-ring) "Translation 5")))
+
+  (poly-translate-test-teardown))
+
+;;; Multiple Results Display Tests
+
+(ert-deftest poly-translate-test-multiple-results-display ()
+  "Test multiple translation results display."
+  (poly-translate-test-setup)
+
+  ;; Register multiple engines
+  (poly-translate-test-register-mock-backend 'backend1)
+  (poly-translate-test-register-mock-backend 'backend2)
+  (poly-translate-test-register-mock-engine "Engine 1" 'backend1 "en" "ja")
+  (poly-translate-test-register-mock-engine "Engine 2" 'backend2 "en" "ja")
+
+  (let ((buffer (get-buffer-create "*test-multiple-results*"))
+        (engines '("Engine 1" "Engine 2")))
+
+    ;; Initialize buffer
+    (poly-translate--display-multiple-results-init buffer "Test text" engines)
+
+    (with-current-buffer buffer
+      (let ((content (buffer-string)))
+        (poly-translate-test-should-contain content "Translation Results")
+        (poly-translate-test-should-contain content "Test text")
+        (poly-translate-test-should-contain content "Engine 1")
+        (poly-translate-test-should-contain content "Engine 2")
+        (poly-translate-test-should-contain content "Translating...")))
+
+    ;; Update with translation
+    (poly-translate--update-multiple-results buffer "Engine 1" "Translated by Engine 1")
+
+    (with-current-buffer buffer
+      (let ((content (buffer-string)))
+        (poly-translate-test-should-contain content "Translated by Engine 1")))
+
+    (kill-buffer buffer))
+
+  (poly-translate-test-teardown))
+
+;;; Translation Buffer Commands Tests
+
+(ert-deftest poly-translate-test-refresh-command ()
+  "Test refresh command in translation buffer."
+  (poly-translate-test-setup)
+
+  ;; Set up mock backend and engine
+  (poly-translate-test-register-mock-backend 'mock-backend)
+  (poly-translate-test-register-mock-engine "Mock Engine" 'mock-backend "en" "ja")
+
+  (let ((buffer (get-buffer-create "*test-refresh*")))
+    (with-current-buffer buffer
+      (poly-translate-mode)
+      (setq poly-translate-original-text "Test text")
+      (setq poly-translate-current-engine "Mock Engine"))
+
+    ;; Test refresh
+    (with-current-buffer buffer
+      (should
+       (condition-case nil
+           (progn (poly-translate-refresh) t)
+         (error nil))))
+
+    (kill-buffer buffer))
+
+  (poly-translate-test-teardown))
+
+(ert-deftest poly-translate-test-change-engine-command ()
+  "Test change engine command."
+  (poly-translate-test-setup)
+
+  ;; Register multiple engines
+  (poly-translate-test-register-mock-backend 'backend1)
+  (poly-translate-test-register-mock-backend 'backend2)
+  (poly-translate-test-register-mock-engine "Engine 1" 'backend1 "en" "ja")
+  (poly-translate-test-register-mock-engine "Engine 2" 'backend2 "en" "ja")
+
+  (let ((buffer (get-buffer-create "*test-change-engine*")))
+    (with-current-buffer buffer
+      (poly-translate-mode)
+      (setq poly-translate-original-text "Test text")
+      (setq poly-translate-current-engine "Engine 1"))
+
+    ;; Test change engine
+    (with-current-buffer buffer
+      (cl-letf (((symbol-function 'poly-translate--select-engine)
+                 (lambda () "Engine 2")))
+        (should
+         (condition-case nil
+             (progn (poly-translate-change-engine) t)
+           (error nil)))))
+
+    (kill-buffer buffer))
+
+  (poly-translate-test-teardown))
+
+;;; Customization Tests
+
+(ert-deftest poly-translate-test-custom-separators ()
+  "Test custom separator configuration."
+  (should (stringp poly-translate-separator-main))
+  (should (stringp poly-translate-separator-engine))
+  (should (stringp poly-translate-engine-prefix)))
+
+(ert-deftest poly-translate-test-show-original-setting ()
+  "Test show original text setting."
+  (poly-translate-test-setup)
+
+  (let ((poly-translate-show-original nil)
+        (buffer (get-buffer-create "*test-no-original*")))
+
+    (poly-translate--display-result buffer "Mock Engine" "Original" "Translation")
+
+    (with-current-buffer buffer
+      (let ((content (buffer-string)))
+        ;; When show-original is nil, original text should not be in buffer
+        ;; (though it's stored in variable)
+        (should (buffer-live-p buffer))))
+
+    (kill-buffer buffer))
+
+  (poly-translate-test-teardown))
+
+(ert-deftest poly-translate-test-auto-select-buffer-setting ()
+  "Test auto-select buffer setting."
+  (should (boundp 'poly-translate-auto-select-buffer))
+  ;; Just verify the variable exists and can be set
+  (let ((poly-translate-auto-select-buffer nil))
+    (should (not poly-translate-auto-select-buffer)))
+  (let ((poly-translate-auto-select-buffer t))
+    (should poly-translate-auto-select-buffer)))
+
 (provide 'poly-translate-interactive-test)
 ;;; poly-translate-interactive-test.el ends here

--- a/tests/poly-translate-test.el
+++ b/tests/poly-translate-test.el
@@ -310,5 +310,278 @@
   (should (boundp 'poly-translate-buffer-name))
   (should (boundp 'poly-translate-language-codes)))
 
+;;; Language Detection Edge Cases
+
+(ert-deftest poly-translate-test-language-detection-japanese ()
+  "Test Japanese language detection with different character types."
+  (poly-translate-test-setup)
+
+  ;; Test with hiragana
+  (let ((result nil))
+    (poly-translate-detect-language
+     "これはひらがなです"
+     (lambda (lang) (setq result lang))
+     (lambda (err) (error "Detection failed: %s" err)))
+    (should (string= result "ja")))
+
+  ;; Test with katakana
+  (let ((result nil))
+    (poly-translate-detect-language
+     "カタカナテスト"
+     (lambda (lang) (setq result lang))
+     (lambda (err) (error "Detection failed: %s" err)))
+    (should (string= result "ja")))
+
+  ;; Test with kanji
+  (let ((result nil))
+    (poly-translate-detect-language
+     "漢字混在文章"
+     (lambda (lang) (setq result lang))
+     (lambda (err) (error "Detection failed: %s" err)))
+    (should (string= result "ja")))
+
+  (poly-translate-test-teardown))
+
+(ert-deftest poly-translate-test-language-detection-other-languages ()
+  "Test language detection for various languages."
+  (poly-translate-test-setup)
+
+  ;; Test Korean
+  (let ((result nil))
+    (poly-translate-detect-language
+     "안녕하세요"
+     (lambda (lang) (setq result lang))
+     (lambda (err) (error "Detection failed: %s" err)))
+    (should (string= result "ko")))
+
+  ;; Test Arabic
+  (let ((result nil))
+    (poly-translate-detect-language
+     "مرحبا"
+     (lambda (lang) (setq result lang))
+     (lambda (err) (error "Detection failed: %s" err)))
+    (should (string= result "ar")))
+
+  ;; Test English (default)
+  (let ((result nil))
+    (poly-translate-detect-language
+     "Hello world"
+     (lambda (lang) (setq result lang))
+     (lambda (err) (error "Detection failed: %s" err)))
+    (should (string= result "en")))
+
+  (poly-translate-test-teardown))
+
+;;; Backend Listing Tests
+
+(ert-deftest poly-translate-test-list-backends ()
+  "Test backend listing functionality."
+  (poly-translate-test-setup)
+
+  ;; Register multiple backends
+  (poly-translate-test-register-mock-backend 'backend1)
+  (poly-translate-test-register-mock-backend 'backend2)
+  (poly-translate-test-register-mock-backend 'backend3)
+
+  (let ((backends (poly-translate-list-backends)))
+    (should (= (length backends) 3))
+    (should (member 'backend1 backends))
+    (should (member 'backend2 backends))
+    (should (member 'backend3 backends)))
+
+  (poly-translate-test-teardown))
+
+;;; Engine Information Tests
+
+(ert-deftest poly-translate-test-engine-config-storage ()
+  "Test that engine config is properly stored."
+  (poly-translate-test-setup)
+
+  (poly-translate-register-engine
+   '(:name "Test Engine"
+     :backend test-backend
+     :input-lang "ja"
+     :output-lang "en"
+     :api-key "test-key"
+     :custom-param "custom-value"))
+
+  (let* ((engine (poly-translate-get-engine "Test Engine"))
+         (config (poly-translate-engine-config engine)))
+    (should (plist-get config :api-key))
+    (should (string= (plist-get config :api-key) "test-key"))
+    (should (plist-get config :custom-param))
+    (should (string= (plist-get config :custom-param) "custom-value")))
+
+  (poly-translate-test-teardown))
+
+(ert-deftest poly-translate-test-engine-default-input-lang ()
+  "Test that input language defaults to 'auto'."
+  (poly-translate-test-setup)
+
+  (poly-translate-register-engine
+   '(:name "Test Engine"
+     :backend test-backend
+     :output-lang "en"))
+
+  (let ((engine (poly-translate-get-engine "Test Engine")))
+    (should (string= (poly-translate-engine-input-lang engine) "auto")))
+
+  (poly-translate-test-teardown))
+
+;;; Cache Edge Cases
+
+(ert-deftest poly-translate-test-cache-different-backends ()
+  "Test cache isolation between different backends."
+  (poly-translate-test-setup)
+
+  ;; Cache same text for different backends
+  (poly-translate-backend-cache-put 'backend1 "hello" "en" "ja" "こんにちは")
+  (poly-translate-backend-cache-put 'backend2 "hello" "en" "ja" "ハロー")
+
+  ;; Each backend should have its own cached value
+  (let ((cache1 (poly-translate-backend-cache-get 'backend1 "hello" "en" "ja"))
+        (cache2 (poly-translate-backend-cache-get 'backend2 "hello" "en" "ja")))
+    (should (string= cache1 "こんにちは"))
+    (should (string= cache2 "ハロー")))
+
+  (poly-translate-test-teardown))
+
+(ert-deftest poly-translate-test-cache-different-language-pairs ()
+  "Test cache with different language pairs."
+  (poly-translate-test-setup)
+
+  ;; Cache same text for different language pairs
+  (poly-translate-backend-cache-put 'test-backend "hello" "en" "ja" "こんにちは")
+  (poly-translate-backend-cache-put 'test-backend "hello" "en" "fr" "bonjour")
+  (poly-translate-backend-cache-put 'test-backend "hello" "ja" "en" "hello")
+
+  ;; Each pair should have its own cached value
+  (let ((cache-en-ja (poly-translate-backend-cache-get 'test-backend "hello" "en" "ja"))
+        (cache-en-fr (poly-translate-backend-cache-get 'test-backend "hello" "en" "fr"))
+        (cache-ja-en (poly-translate-backend-cache-get 'test-backend "hello" "ja" "en")))
+    (should (string= cache-en-ja "こんにちは"))
+    (should (string= cache-en-fr "bonjour"))
+    (should (string= cache-ja-en "hello")))
+
+  (poly-translate-test-teardown))
+
+;;; Rate Limiting Edge Cases
+
+(ert-deftest poly-translate-test-rate-limiting-different-backends ()
+  "Test that rate limiting is independent per backend."
+  (poly-translate-test-setup)
+
+  ;; Backend1 can make 1 request per second
+  (should (poly-translate-backend-check-rate-limit 'backend1 1 1))
+  (should-not (poly-translate-backend-check-rate-limit 'backend1 1 1))
+
+  ;; Backend2 should not be affected by backend1's limit
+  (should (poly-translate-backend-check-rate-limit 'backend2 1 1))
+  (should-not (poly-translate-backend-check-rate-limit 'backend2 1 1))
+
+  (poly-translate-test-teardown))
+
+(ert-deftest poly-translate-test-rate-limiting-burst ()
+  "Test rate limiting with burst requests."
+  (poly-translate-test-setup)
+
+  ;; Allow 3 requests per 2 seconds
+  (should (poly-translate-backend-check-rate-limit 'test-backend 3 2))
+  (should (poly-translate-backend-check-rate-limit 'test-backend 3 2))
+  (should (poly-translate-backend-check-rate-limit 'test-backend 3 2))
+  (should-not (poly-translate-backend-check-rate-limit 'test-backend 3 2))
+
+  (poly-translate-test-teardown))
+
+;;; Duplicate Engine Registration
+
+(ert-deftest poly-translate-test-duplicate-engine-registration ()
+  "Test that registering an engine with the same name overwrites the previous one."
+  (poly-translate-test-setup)
+
+  (poly-translate-test-register-mock-backend 'backend1)
+  (poly-translate-test-register-mock-backend 'backend2)
+
+  ;; Register first engine
+  (poly-translate-test-register-mock-engine "Test Engine" 'backend1 "en" "ja")
+  (let ((engine (poly-translate-get-engine "Test Engine")))
+    (should (eq (poly-translate-engine-backend engine) 'backend1)))
+
+  ;; Register again with same name but different backend
+  (poly-translate-test-register-mock-engine "Test Engine" 'backend2 "ja" "en")
+  (let ((engine (poly-translate-get-engine "Test Engine")))
+    (should (eq (poly-translate-engine-backend engine) 'backend2))
+    (should (string= (poly-translate-engine-input-lang engine) "ja"))
+    (should (string= (poly-translate-engine-output-lang engine) "en")))
+
+  (poly-translate-test-teardown))
+
+;;; Language Name Formatting
+
+(ert-deftest poly-translate-test-language-name-unknown ()
+  "Test language name formatting for unknown codes."
+  (let ((name (poly-translate-language-name "xyz")))
+    (should (string= name "xyz"))))
+
+(ert-deftest poly-translate-test-language-name-auto ()
+  "Test language name formatting for 'auto'."
+  ;; Assuming "auto" is handled by poly-translate-language-codes
+  (let ((name (poly-translate-language-name "auto")))
+    (should (stringp name))))
+
+;;; Empty Text Handling
+
+(ert-deftest poly-translate-test-empty-text-translation ()
+  "Test translation with empty text."
+  (poly-translate-test-setup)
+
+  (poly-translate-test-register-mock-backend 'mock-backend)
+  (poly-translate-test-register-mock-engine "Mock Engine" 'mock-backend "en" "ja")
+
+  ;; Test with empty string
+  (let ((result nil))
+    (poly-translate-with-engine
+     "Mock Engine"
+     ""
+     (lambda (translation) (setq result translation))
+     (lambda (err) (error "Translation failed: %s" err)))
+    ;; Empty text should still be processed by backend
+    (should result))
+
+  (poly-translate-test-teardown))
+
+;;; Callback Error Handling
+
+(ert-deftest poly-translate-test-callback-with-nil-error-callback ()
+  "Test that nil error callback is handled gracefully."
+  (poly-translate-test-setup)
+
+  ;; Register backend that always fails
+  (poly-translate-register-backend
+   'failing-backend
+   `(:translate ,(lambda (backend text from-lang to-lang config callback error-callback)
+                   (funcall error-callback "Test error"))
+     :validate-config ,(lambda (backend config) t)))
+
+  (poly-translate-register-engine
+   '(:name "Failing Engine"
+     :backend failing-backend
+     :input-lang "en"
+     :output-lang "ja"))
+
+  ;; Should not crash when error-callback is nil
+  (should
+   (condition-case nil
+       (progn
+         (poly-translate-with-engine
+          "Failing Engine"
+          "test"
+          (lambda (result) nil)
+          nil)  ; nil error callback
+         t)
+     (error nil)))
+
+  (poly-translate-test-teardown))
+
 (provide 'poly-translate-test)
 ;;; poly-translate-test.el ends here


### PR DESCRIPTION
Added extensive test coverage for:

Core functionality tests (poly-translate-test.el):
- Language detection edge cases (Japanese hiragana/katakana/kanji, Korean, Arabic)
- Backend listing functionality
- Engine configuration storage and default values
- Cache isolation between backends and language pairs
- Rate limiting for different backends and burst requests
- Duplicate engine registration behavior
- Language name formatting for unknown codes
- Empty text handling
- Callback error handling with nil callbacks

Interactive functionality tests (poly-translate-interactive-test.el):
- Edit original text functionality (start, cancel, toggle)
- All-engines translation (normal, with errors, empty list)
- Translation history management
- Kill ring size limits
- Multiple translation results display
- Translation buffer commands (refresh, change engine)
- Customization settings (separators, show original, auto-select)

These tests improve overall test coverage and ensure robust handling of edge cases and error conditions.